### PR TITLE
Add status polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example plugin configuration:
     "onUrl": "http://10.0.0.9/dimmerOn",
     "offUrl": "http://10.0.0.9/dimmerOff",
     "statusUrl": "http://10.0.0.9/getDimmerState",
+    "statusPollingInterval":5,
     "setBrightnessUrl": "http://10.0.0.9/setBrightness?brightness=",
     "getBrightnessUrl":"http://10.0.0.9/getBrightness"
 }
@@ -25,6 +26,7 @@ name 		: <string> name of the accessory. This is displayed on HomeKit
 onUrl 		: <string> url to turn on the accessory
 offUrl		: <string> url to turn off the accessory
 statusUrl	: <string> returns the status of the accessory (return 1 as body if ON and 0 if OFF)
+statusPollingInterval	: <integer> number of seconds to poll status
 setBrightnessUrl : <string> url, to whose end brightness will be appended
 getBrightnessURl : <string> url which will return the value of brightness in the body
 ```

--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ class DimmerAccessory {
       if(body == 0){
         this.isOn = false
       } else {
-        this.log()
         this.isOn = true
       }
       callback(null, this.isOn)

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ class DimmerAccessory {
     this.setBrightnessUrl = config.setBrightnessUrl
     this.getBrightnessUrl = config.getBrightnessUrl
     this.service = new Service.Lightbulb(this.config.name)
+    this.pollingInterval = parseInt(config.pollingInterval || 5)
+    this.pollingTimeout = null
   }
 
   getServices () {
@@ -38,7 +40,20 @@ class DimmerAccessory {
       .on('get', this.getBrightness.bind(this))
       .on('set', this.setBrightness.bind(this));
 
+    this.statePolling()
+
     return [informationService, this.service]
+  }
+
+  statePolling () {
+    clearTimeout(this.pollingTimeOut)
+    this.service.getCharacteristic(Characteristic.On).getValue()
+    this.service.getCharacteristic(Characteristic.Brightness).getValue()
+
+    this.pollingTimeOut = setTimeout(
+      this.statePolling.bind(this),
+      this.pollingInterval * 1000
+    )
   }
 
   getBrightness (callback) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class DimmerAccessory {
 
   setBrightness (value, callback) {
     this.brightness = value
-    this.log('setting brightness ', value)
+    this.log('Setting brightness:', value)
     request(`${this.setBrightnessUrl}${value}`, (err, resp, body) => {
       callback(null, value)
     })


### PR DESCRIPTION
This PR improves a few things with logging and adds status polling of accessories so that their power and brightness is accurately reflected in HomeKit after the accessory's state changes from an external action.